### PR TITLE
Removed unnecessary glslang #include from ShaderModule.h

### DIFF
--- a/vkhlf/Device.h
+++ b/vkhlf/Device.h
@@ -34,6 +34,7 @@
 #include <vkhlf/PipelineLayout.h>
 #include <vkhlf/Sampler.h>
 #include <vkhlf/Types.h>
+#include <map>
 
 namespace vkhlf
 {

--- a/vkhlf/ShaderModule.h
+++ b/vkhlf/ShaderModule.h
@@ -31,7 +31,6 @@
 #include <vkhlf/Types.h>
 #include <vkhlf/Reference.h>
 #include <vector>
-#include <map>
 
 namespace vkhlf
 {

--- a/vkhlf/ShaderModule.h
+++ b/vkhlf/ShaderModule.h
@@ -30,8 +30,8 @@
 #include <vkhlf/Config.h>
 #include <vkhlf/Types.h>
 #include <vkhlf/Reference.h>
-#include <glslang/SPIRV/GlslangToSpv.h>
 #include <vector>
+#include <map>
 
 namespace vkhlf
 {


### PR DESCRIPTION
This should have been fixed with #14, but there is still one public header file which needlessly includes a glslang header. Removing that `#include` makes the public interface entirely independent from glslang.