### PR TITLE
Fix for FramebufferSwapchain::present(...) arguments

### DIFF
--- a/vkhlf/FramebufferSwapchain.h
+++ b/vkhlf/FramebufferSwapchain.h
@@ -62,9 +62,9 @@ namespace vkhlf {
         // wait for this semaphore before rendering
         std::shared_ptr<Semaphore> const&   getPresentSemaphore() const { return m_swapchain->getPresentCompleteSemaphores()[m_swapchainIndex]; }
 
-        void present(std::shared_ptr<Queue> const& queue, std::shared_ptr<Semaphore> const & waitSemaphore = {})
+        void present(std::shared_ptr<Queue> const& queue, vk::ArrayProxy<const std::shared_ptr<Semaphore>> waitSemaphores = {})
         {
-            queue->present(waitSemaphore, m_swapchain, m_swapchainIndex);
+            queue->present(waitSemaphores, m_swapchain, m_swapchainIndex);
         }
 
     private:


### PR DESCRIPTION
`Queue::present(...)` supports any number of wait semaphores, but `FramebufferSwapchain::present(...)` needlessly assumes there is exactly one provided. In particular, calling `FramebufferSwapchain::present(...)` with only the first argument (no wait semaphores), initializes `waitSemaphore` to `{}`, but since it is a `shared_ptr`, it becomes a null pointer, leading to immediate crash when it gets dereferenced.

This fixes the issue, by changing the type of `waitSemaphore` in `FramebufferSwapchain::present(...)` to a list of semaphores: `vk::ArrayProxy<const std::shared_ptr<Semaphore>>`.