### PR TITLE
Added a richer variant of FramebufferSwapchain::acquireNextFrame()

### DIFF
--- a/vkhlf/FramebufferSwapchain.h
+++ b/vkhlf/FramebufferSwapchain.h
@@ -46,6 +46,7 @@ namespace vkhlf {
             std::shared_ptr<Allocator> const& imageViewAllocator = nullptr);
 
         void acquireNextFrame() { m_swapchainIndex = m_swapchain->acquireNextImage(); }
+        void acquireNextFrame(uint64_t timeout, std::shared_ptr<Fence> const& fence) { m_swapchainIndex = m_swapchain->acquireNextImage(timeout, fence); }
 
         std::shared_ptr<Framebuffer> const& getFramebuffer() const { return m_framebuffers[m_swapchainIndex]; }
 

--- a/vkhlf/FramebufferSwapchain.h
+++ b/vkhlf/FramebufferSwapchain.h
@@ -45,8 +45,7 @@ namespace vkhlf {
             std::shared_ptr<Allocator> const& imageAllocator = nullptr,
             std::shared_ptr<Allocator> const& imageViewAllocator = nullptr);
 
-        void acquireNextFrame() { m_swapchainIndex = m_swapchain->acquireNextImage(); }
-        void acquireNextFrame(uint64_t timeout, std::shared_ptr<Fence> const& fence) { m_swapchainIndex = m_swapchain->acquireNextImage(timeout, fence); }
+        void acquireNextFrame(uint64_t timeout = UINT64_MAX, std::shared_ptr<Fence> const& fence = {}) { m_swapchainIndex = m_swapchain->acquireNextImage(timeout, fence); }
 
         std::shared_ptr<Framebuffer> const& getFramebuffer() const { return m_framebuffers[m_swapchainIndex]; }
 


### PR DESCRIPTION
`Swapchain::acquireNextImage()` has two optional arguments (timeout and fence), but `FramebufferSwapchain::acquireNextFrame()` always uses their default values.

This branch implements an extra variant of `FramebufferSwapchain::acquireNextImage(...)` - one that uses a fence provided by the caller.