### PR TITLE
Fixed shader link error messages taken from incorrect source

### DIFF
--- a/vkhlf/src/ShaderModule.cpp
+++ b/vkhlf/src/ShaderModule.cpp
@@ -201,8 +201,8 @@ namespace vkhlf
 
     if (!program.link(messages))
     {
-      std::string infoLog = shader.getInfoLog();
-      std::string infoDebugLog = shader.getInfoDebugLog();
+      std::string infoLog = program.getInfoLog();
+      std::string infoDebugLog = program.getInfoDebugLog();
       assert(false);
     }
 


### PR DESCRIPTION
When a `glslang::TProgram::link(...)` fails, error messages are provided via `glslang:: TProgram::getInfoLog()`, not `glslang::TShader::getInfoLog()`.

This fix does not change behavior much, since there is an `assert(false)` immediately below (and, generally, the shader compilation routine looks as if it was a temporary solution and may get rewritten in future), but given how VkHLF is a valuable learning resource, I decided to correct this mistake.