### PR TITLE
Fixed uninitialized m_swapchainIndex

### DIFF
--- a/vkhlf/FramebufferSwapchain.h
+++ b/vkhlf/FramebufferSwapchain.h
@@ -70,7 +70,7 @@ namespace vkhlf {
     private:
         vk::Extent2D                              m_extent;
         std::shared_ptr<Swapchain>                m_swapchain;
-        uint32_t                                  m_swapchainIndex = 0; // current swapchain index
+        uint32_t                                  m_swapchainIndex; // current swapchain index
         std::vector<std::shared_ptr<Image>>       m_colorImages;
         std::vector<std::shared_ptr<ImageView>>   m_colorViews;
         std::shared_ptr<Image>                    m_depthImage;

--- a/vkhlf/FramebufferSwapchain.h
+++ b/vkhlf/FramebufferSwapchain.h
@@ -70,7 +70,7 @@ namespace vkhlf {
     private:
         vk::Extent2D                              m_extent;
         std::shared_ptr<Swapchain>                m_swapchain;
-        uint32_t                                  m_swapchainIndex; // current swapchain index
+        uint32_t                                  m_swapchainIndex = 0; // current swapchain index
         std::vector<std::shared_ptr<Image>>       m_colorImages;
         std::vector<std::shared_ptr<ImageView>>   m_colorViews;
         std::shared_ptr<Image>                    m_depthImage;

--- a/vkhlf/src/FramebufferSwapchain.cpp
+++ b/vkhlf/src/FramebufferSwapchain.cpp
@@ -45,6 +45,7 @@ namespace vkhlf {
         std::shared_ptr<Allocator> const& swapchainAllocator,
         std::shared_ptr<Allocator> const& imageAllocator,
         std::shared_ptr<Allocator> const& imageViewAllocator)
+      : m_swapchainIndex(0)
     {
         vk::SurfaceCapabilitiesKHR surfaceCapabilities = device->get<PhysicalDevice>()->getSurfaceCapabilities(surface);
         assert(surfaceCapabilities.currentExtent.width != -1);


### PR DESCRIPTION
`m_swapchainIndex` in `FramebufferSwapchain` is never initialized to 0, which leads to occasional crashes.