### PR TITLE
Fixing the enabling of fetaures on Device creation

### DIFF
--- a/vkhlf/src/Device.cpp
+++ b/vkhlf/src/Device.cpp
@@ -112,7 +112,7 @@ namespace vkhlf
     }
 
     vk::DeviceCreateInfo createInfo({}, vkhlf::checked_cast<uint32_t>(queueCIs.size()), queueCIs.data(), vkhlf::checked_cast<uint32_t>(layers.size()), layers.data(),
-      vkhlf::checked_cast<uint32_t>(extensions.size()), extensions.data());
+      vkhlf::checked_cast<uint32_t>(extensions.size()), extensions.data(), &enabledFeatures);
     m_device = static_cast<vk::PhysicalDevice>(*get<PhysicalDevice>()).createDevice(createInfo, *get<Allocator>());
 
     for (auto const& createInfo : queueCreateInfos)


### PR DESCRIPTION
I noticed when trying to enable features that they weren't being enabled. I looked into it and it seemed as though VkHLF was simply throwing the argument away. 

Seems like just adding it into the vk::DeviceCreateInfo constructor call, it works!