### PR TITLE
Resolve issues raised from errorDebugCallback

### DIFF
--- a/samples/02_triangle/src/02_triangle.cpp
+++ b/samples/02_triangle/src/02_triangle.cpp
@@ -145,7 +145,7 @@ Window::Window(char const* title, int width, int height)
   vkhlf::PipelineVertexInputStateCreateInfo vertexInput(binding, { attrib0, attrib1 });
   vk::PipelineInputAssemblyStateCreateInfo assembly({}, vk::PrimitiveTopology::eTriangleList, VK_FALSE);
   vkhlf::PipelineViewportStateCreateInfo viewport({ {} }, { {} });   // one dummy viewport and scissor, as dynamic state sets them
-  vk::PipelineRasterizationStateCreateInfo rasterization({}, true, false, vk::PolygonMode::eFill, vk::CullModeFlagBits::eBack, vk::FrontFace::eClockwise, false, 0.0f, 0.0f, 0.0f, 1.0f);
+  vk::PipelineRasterizationStateCreateInfo rasterization({}, false, false, vk::PolygonMode::eFill, vk::CullModeFlagBits::eBack, vk::FrontFace::eClockwise, false, 0.0f, 0.0f, 0.0f, 1.0f);
   vkhlf::PipelineMultisampleStateCreateInfo multisample(vk::SampleCountFlagBits::e1, false, 0.0f, nullptr, false, false);
   vk::StencilOpState stencilOpState(vk::StencilOp::eKeep, vk::StencilOp::eKeep, vk::StencilOp::eKeep, vk::CompareOp::eAlways, 0, 0, 0);
   vk::PipelineDepthStencilStateCreateInfo depthStencil({}, true, true, vk::CompareOp::eLessOrEqual, false, false, stencilOpState, stencilOpState, 0.0f, 0.0f);

--- a/samples/VkHLFSampleUtils/src/VkHLFSampleWindow.cpp
+++ b/samples/VkHLFSampleUtils/src/VkHLFSampleWindow.cpp
@@ -111,7 +111,7 @@ VkHLFSampleWindow::VkHLFSampleWindow(char const * title, int width, int height)
   m_depthFormat = vk::Format::eD24UnormS8Uint;
 
   // Create a new device with the VK_KHR_SWAPCHAIN_EXTENSION enabled.
-  m_device = m_physicalDevice->createDevice(vkhlf::DeviceQueueCreateInfo(m_queueFamilyIndex, 0.0f), nullptr, { VK_KHR_SWAPCHAIN_EXTENSION_NAME });
+  m_device = m_physicalDevice->createDevice(vkhlf::DeviceQueueCreateInfo(m_queueFamilyIndex, 0.0f), nullptr, { VK_KHR_SWAPCHAIN_EXTENSION_NAME }, m_physicalDevice->getFeatures());
 
   m_graphicsQueue = m_device->getQueue(m_queueFamilyIndex, 0);
 

--- a/vkhlf/Device.h
+++ b/vkhlf/Device.h
@@ -158,6 +158,7 @@ namespace vkhlf
                                                         vk::SurfaceTransformFlagBitsKHR preTransform, vk::CompositeAlphaFlagBitsKHR compositeAlpha, vk::PresentModeKHR presentMode, bool clipped,
                                                         std::shared_ptr<Swapchain> const& oldSwapchain = nullptr, std::shared_ptr<Allocator> const& allocator = nullptr);
 
+      VKHLF_API vk::PhysicalDeviceFeatures const&      getEnabledFeatures() const;
       VKHLF_API PFN_vkVoidFunction                     getProcAddress(std::string const& name) const;
       VKHLF_API std::shared_ptr<Queue>                 getQueue(uint32_t familyIndex, uint32_t queueIndex);
       VKHLF_API size_t                                 getQueueCount(uint32_t familyIndex) const;
@@ -178,6 +179,7 @@ namespace vkhlf
                           vk::ArrayProxy<const std::string> enabledExtensionNames, vk::PhysicalDeviceFeatures const& enabledFeatures);
 
       vk::Device                                                     m_device;
+      vk::PhysicalDeviceFeatures                                     m_enabledFeatures;
       std::map<uint32_t, std::vector<std::unique_ptr<vkhlf::Queue>>> m_queues; // key is queueFamilyIndex
   };
 

--- a/vkhlf/src/Device.cpp
+++ b/vkhlf/src/Device.cpp
@@ -68,8 +68,8 @@ namespace vkhlf
   }
 
   std::shared_ptr<Device> Device::create(std::shared_ptr<PhysicalDevice> const& physicalDevice, vk::ArrayProxy<const DeviceQueueCreateInfo> queueCreateInfos,
-    vk::ArrayProxy<const std::string> enabledLayerNames, vk::ArrayProxy<const std::string> enabledExtensionNames,
-    vk::PhysicalDeviceFeatures const& enabledFeatures, std::shared_ptr<Allocator> const& allocator)
+                                         vk::ArrayProxy<const std::string> enabledLayerNames, vk::ArrayProxy<const std::string> enabledExtensionNames,
+                                         vk::PhysicalDeviceFeatures const& enabledFeatures, std::shared_ptr<Allocator> const& allocator)
   {
     std::shared_ptr<Device> device(new Device(physicalDevice, allocator));
     device->init(queueCreateInfos, enabledLayerNames, enabledExtensionNames, enabledFeatures);
@@ -111,8 +111,9 @@ namespace vkhlf
       extensions.push_back(s.c_str());
     }
 
+    m_enabledFeatures = enabledFeatures;
     vk::DeviceCreateInfo createInfo({}, vkhlf::checked_cast<uint32_t>(queueCIs.size()), queueCIs.data(), vkhlf::checked_cast<uint32_t>(layers.size()), layers.data(),
-      vkhlf::checked_cast<uint32_t>(extensions.size()), extensions.data(), &enabledFeatures);
+                                    vkhlf::checked_cast<uint32_t>(extensions.size()), extensions.data(), &m_enabledFeatures);
     m_device = static_cast<vk::PhysicalDevice>(*get<PhysicalDevice>()).createDevice(createInfo, *get<Allocator>());
 
     for (auto const& createInfo : queueCreateInfos)
@@ -132,6 +133,11 @@ namespace vkhlf
   {
     m_queues.clear();
     m_device.destroy(*get<Allocator>());
+  }
+
+  vk::PhysicalDeviceFeatures const& Device::getEnabledFeatures() const
+  {
+    return m_enabledFeatures;
   }
 
   PFN_vkVoidFunction Device::getProcAddress(std::string const& name) const


### PR DESCRIPTION
- create Device using the Features of the physicalDevice, instead of a default set of Features
- extend vkhlf::Device to hold the enabled features
- improve function setImageLayout in CommandBuffer.cpp to determine srcStageMask and dstStageMask the srcAccessMask and the dstAccessMask, respectively, used for the imageMemoryBarrier, and the enabled features from the device

+ add "Press Enter to exit" at end of VulkanInfo.