### PR TITLE
Add basic support for Apple platforms/MoltenVK

### DIFF
--- a/vkhlf/Config.h
+++ b/vkhlf/Config.h
@@ -44,6 +44,19 @@
 # define _stricmp strcasecmp
 #endif
 
+#if defined(__APPLE__)
+#define VK_POSIX
+
+#include <TargetConditionals.h>
+# if defined(TARGET_OS_IOS)
+#  define VK_OS_IOS
+# elif defined(TARGET_OS_MAC)
+#  define VK_OS_MAC
+#endif
+
+#include <MoltenVK/mvk_vulkan.h>
+
+#endif
 
 #if defined(VK_OS_WINDOWS)
 // microsoft specific storage-class defines

--- a/vkhlf/Instance.h
+++ b/vkhlf/Instance.h
@@ -70,6 +70,12 @@ namespace vkhlf
 #ifdef VK_USE_PLATFORM_XCB_KHR
              std::shared_ptr<Surface>             createSurface(xcb_connection_t * connection, xcb_window_t window, std::shared_ptr<Allocator> const& allocator = nullptr);
 #endif
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+             std::shared_ptr<Surface>             createSurface(/*NSView*/ void * view, int, std::shared_ptr<Allocator> const& allocator = nullptr);
+#endif
+#ifdef VK_USE_PLATFORM_IOS_MVK
+             std::shared_ptr<Surface>             createSurface(/*UIView*/ void * view, int, std::shared_ptr<Allocator> const& allocator = nullptr);
+#endif
 #ifdef GLFW_INCLUDE_VULKAN
              std::shared_ptr<Surface>             createSurface(GLFWwindow * window, std::shared_ptr<Allocator> const& allocator = nullptr);
 #endif
@@ -134,6 +140,20 @@ namespace vkhlf
   {
     return std::make_shared<Surface>(shared_from_this(), m_instance.createXcbSurfaceKHR(vk::XcbSurfaceCreateInfoKHR({}, connection, window), *allocator), allocator);
   }
+#endif
+
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    inline std::shared_ptr<Surface> Instance::createSurface(void * view, int, std::shared_ptr<Allocator> const& allocator)
+    {
+        return std::make_shared<Surface>(shared_from_this(), m_instance.createMacOSSurfaceMVK(vk::MacOSSurfaceCreateInfoMVK({}, view), *allocator), allocator);
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_IOS_MVK
+    inline std::shared_ptr<Surface> Instance::createSurface(void * view, int, std::shared_ptr<Allocator> const& allocator)
+    {
+        return std::make_shared<Surface>(shared_from_this(), m_instance.createIOSSurfaceMVK(vk::IOSSurfaceCreateInfoMVK({}, view), *allocator), allocator);
+    }
 #endif
 
 #ifdef GLFW_INCLUDE_VULKAN

--- a/vkhlf/src/Display.cpp
+++ b/vkhlf/src/Display.cpp
@@ -26,6 +26,7 @@
 */
 
 
+#include <vkhlf/Config.h>
 #include <vkhlf/Display.h>
 #include <vkhlf/DisplayMode.h>
 
@@ -41,7 +42,11 @@ namespace vkhlf
 
   std::vector<DisplayModeProperties> Display::getDisplayModeProperties()
   {
-    std::vector<vk::DisplayModePropertiesKHR> vkDisplayModeProperties = static_cast<vk::PhysicalDevice>(*get<PhysicalDevice>()).getDisplayModePropertiesKHR(m_display);
+    std::vector<vk::DisplayModePropertiesKHR> vkDisplayModeProperties
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
+    = static_cast<vk::PhysicalDevice>(*get<PhysicalDevice>()).getDisplayModePropertiesKHR(m_display)
+#endif
+    ;
     std::vector<DisplayModeProperties> displayModeProperties;
     displayModeProperties.reserve(vkDisplayModeProperties.size());
     for (auto const& dmp : vkDisplayModeProperties)

--- a/vkhlf/src/DisplayMode.cpp
+++ b/vkhlf/src/DisplayMode.cpp
@@ -26,6 +26,7 @@
 */
 
 
+#include <vkhlf/Config.h>
 #include <vkhlf/Display.h>
 #include <vkhlf/DisplayMode.h>
 
@@ -36,18 +37,24 @@ namespace vkhlf
     , m_displayMode(displayMode)
   {}
 
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
   DisplayMode::DisplayMode(std::shared_ptr<Display> const& display, vk::Extent2D const& visibleRegion, uint32_t refreshRate)
     : Reference(display)
   {
     vk::DisplayModeCreateInfoKHR createInfo({}, vk::DisplayModeParametersKHR(visibleRegion, refreshRate));
     m_displayMode = static_cast<vk::PhysicalDevice>(*get<Display>()->get<PhysicalDevice>()).createDisplayModeKHR(static_cast<vk::DisplayKHR>(*get<Display>()), createInfo);
   }
+#endif
 
   DisplayMode::~DisplayMode()
   {}    // NOTE: there's no destroyDisplayModeKHR !!
 
   vk::DisplayPlaneCapabilitiesKHR DisplayMode::getPlaneCapabilities(uint32_t planeIndex) const
   {
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
     return static_cast<vk::PhysicalDevice>(*get<Display>()->get<PhysicalDevice>()).getDisplayPlaneCapabilitiesKHR(m_displayMode, planeIndex);
+#else
+    return vk::DisplayPlaneCapabilitiesKHR();
+#endif
   }
 } // namespace vk

--- a/vkhlf/src/PhysicalDevice.cpp
+++ b/vkhlf/src/PhysicalDevice.cpp
@@ -26,6 +26,7 @@
 */
 
 
+#include <vkhlf/Config.h>
 #include <vkhlf/Device.h>
 #include <vkhlf/Display.h>
 #include <vkhlf/PhysicalDevice.h>
@@ -79,7 +80,11 @@ namespace vkhlf
 
   std::vector<DisplayPlaneProperties> PhysicalDevice::getDisplayPlaneProperties()
   {
-    std::vector<vk::DisplayPlanePropertiesKHR> vkDisplayPlaneProperties = m_physicalDevice.getDisplayPlanePropertiesKHR();
+    std::vector<vk::DisplayPlanePropertiesKHR> vkDisplayPlaneProperties
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
+    = m_physicalDevice.getDisplayPlanePropertiesKHR()
+#endif
+    ;
     std::vector<DisplayPlaneProperties> displayPlaneProperties;
     displayPlaneProperties.reserve(vkDisplayPlaneProperties.size());
     for (auto const& dpp : vkDisplayPlaneProperties)
@@ -91,7 +96,11 @@ namespace vkhlf
 
   std::vector<DisplayProperties> PhysicalDevice::getDisplayProperties()
   {
-    std::vector<vk::DisplayPropertiesKHR> vkDisplayProperties = m_physicalDevice.getDisplayPropertiesKHR();
+    std::vector<vk::DisplayPropertiesKHR> vkDisplayProperties
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
+    = m_physicalDevice.getDisplayPropertiesKHR()
+#endif
+    ;
     std::vector<DisplayProperties> displayProperties;
     displayProperties.reserve(vkDisplayProperties.size());
     for (auto const& dp : vkDisplayProperties)
@@ -169,7 +178,11 @@ namespace vkhlf
 
   std::vector<std::shared_ptr<Display>> PhysicalDevice::getSupportedDisplays(uint32_t planeIndex)
   {
-    std::vector<vk::DisplayKHR> vkDisplays = m_physicalDevice.getDisplayPlaneSupportedDisplaysKHR(planeIndex);
+    std::vector<vk::DisplayKHR> vkDisplays
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
+    = m_physicalDevice.getDisplayPlaneSupportedDisplaysKHR(planeIndex)
+#endif    
+    ;
     std::vector<std::shared_ptr<Display>> displays;
     displays.reserve(vkDisplays.size());
     for (auto const& d : vkDisplays)

--- a/vkhlf/src/Pipeline.cpp
+++ b/vkhlf/src/Pipeline.cpp
@@ -31,7 +31,7 @@
 #include <vkhlf/PipelineCache.h>
 #include <vkhlf/RenderPass.h>
 #include <array>
-#include <math.h>
+#include <cmath>
 
 namespace vkhlf
 {
@@ -96,7 +96,7 @@ namespace vkhlf
     , alphaToCoverageEnable(alphaToCoverageEnable_)
     , alphaToOneEnable(alphaToOneEnable_)
   {
-    assert(sampleMasks.empty() || (ceil(static_cast<uint32_t>(sampleShadingEnable) / 32) <= sampleMasks.size()));
+    assert(sampleMasks.empty() || (std::ceil(static_cast<uint32_t>(sampleShadingEnable) / 32) <= sampleMasks.size()));
   }
 
   PipelineMultisampleStateCreateInfo::PipelineMultisampleStateCreateInfo(PipelineMultisampleStateCreateInfo const& rhs)

--- a/vkhlf/src/Pipeline.cpp
+++ b/vkhlf/src/Pipeline.cpp
@@ -31,6 +31,7 @@
 #include <vkhlf/PipelineCache.h>
 #include <vkhlf/RenderPass.h>
 #include <array>
+#include <math.h>
 
 namespace vkhlf
 {

--- a/vkhlf/src/Surface.cpp
+++ b/vkhlf/src/Surface.cpp
@@ -26,6 +26,7 @@
 */
 
 
+#include <vkhlf/Config.h>
 #include <vkhlf/Device.h>
 #include <vkhlf/DisplayMode.h>
 #include <vkhlf/Fence.h>
@@ -41,6 +42,7 @@ namespace vkhlf
     , m_surface(surface)
   {}
 
+#if !defined(VK_OS_MAC) && !defined(VK_OS_IOS)
   Surface::Surface(std::shared_ptr<Instance> const& instance, std::shared_ptr<DisplayMode> const& displayMode, uint32_t planeIndex, uint32_t planeStackIndex,
                    vk::SurfaceTransformFlagBitsKHR transform, float globalAlpha, vk::DisplayPlaneAlphaFlagBitsKHR alphaMode, vk::Extent2D const& imageExtent,
                    std::shared_ptr<Allocator> const& allocator)
@@ -49,6 +51,7 @@ namespace vkhlf
     vk::DisplaySurfaceCreateInfoKHR createInfo({}, static_cast<vk::DisplayModeKHR>(*displayMode), planeIndex, planeStackIndex, transform, globalAlpha, alphaMode, imageExtent);
     m_surface = static_cast<vk::Instance>(*get<Instance>()).createDisplayPlaneSurfaceKHR(createInfo, *get<Allocator>());
   }
+#endif
 
   Surface::~Surface()
   {


### PR DESCRIPTION
On macOS, Xcode 9.2: Fixes "Use of undeclared identifier"