### PR TITLE
Change CommandBuffer::pushConstants api to match other APIs

### DIFF
--- a/vkhlf/CommandBuffer.h
+++ b/vkhlf/CommandBuffer.h
@@ -104,7 +104,7 @@ namespace vkhlf
       VKHLF_API void fillBuffer(std::shared_ptr<vkhlf::Buffer> const& dstBuffer, vk::DeviceSize dstOffset, vk::DeviceSize fillSize, uint32_t data);
       VKHLF_API void nextSubpass(vk::SubpassContents contents);
       VKHLF_API void pipelineBarrier(vk::PipelineStageFlags srcStageMask, vk::PipelineStageFlags destStageMask, vk::DependencyFlags dependencyFlags, vk::ArrayProxy<const vk::MemoryBarrier> barriers, vk::ArrayProxy<const vk::BufferMemoryBarrier> bufferMemoryBarriers, vk::ArrayProxy<const ImageMemoryBarrier> imageMemoryBarriers);
-      template <typename T> void pushConstants(vk::PipelineLayout layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values);
+      template <typename T> void pushConstants(std::shared_ptr<vkhlf::PipelineLayout> layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values);
       VKHLF_API void reset(vk::CommandBufferResetFlags flags = {});
       VKHLF_API void resetEvent(std::shared_ptr<vkhlf::Event> const& event, vk::PipelineStageFlags stageMask);
       VKHLF_API void resetQueryPool(std::shared_ptr<vkhlf::QueryPool> const& queryPool, uint32_t startQuery, uint32_t queryCount);
@@ -204,9 +204,9 @@ namespace vkhlf
   }
 
   template <typename T>
-  inline void CommandBuffer::pushConstants(vk::PipelineLayout layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values)
+  inline void CommandBuffer::pushConstants(std::shared_ptr<vkhlf::PipelineLayout> layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values)
   {
-    m_commandBuffer.pushConstants<T>(layout, stageFlags, start, values);
+    m_commandBuffer.pushConstants<T>((vk::PipelineLayout)*layout, stageFlags, start, values);
   }
 
   template <typename T>

--- a/vkhlf/CommandBuffer.h
+++ b/vkhlf/CommandBuffer.h
@@ -104,7 +104,7 @@ namespace vkhlf
       VKHLF_API void fillBuffer(std::shared_ptr<vkhlf::Buffer> const& dstBuffer, vk::DeviceSize dstOffset, vk::DeviceSize fillSize, uint32_t data);
       VKHLF_API void nextSubpass(vk::SubpassContents contents);
       VKHLF_API void pipelineBarrier(vk::PipelineStageFlags srcStageMask, vk::PipelineStageFlags destStageMask, vk::DependencyFlags dependencyFlags, vk::ArrayProxy<const vk::MemoryBarrier> barriers, vk::ArrayProxy<const vk::BufferMemoryBarrier> bufferMemoryBarriers, vk::ArrayProxy<const ImageMemoryBarrier> imageMemoryBarriers);
-      template <typename T> void pushConstants(std::shared_ptr<vkhlf::PipelineLayout> layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values);
+      template <typename T> void pushConstants(std::shared_ptr<vkhlf::PipelineLayout> const& layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values);
       VKHLF_API void reset(vk::CommandBufferResetFlags flags = {});
       VKHLF_API void resetEvent(std::shared_ptr<vkhlf::Event> const& event, vk::PipelineStageFlags stageMask);
       VKHLF_API void resetQueryPool(std::shared_ptr<vkhlf::QueryPool> const& queryPool, uint32_t startQuery, uint32_t queryCount);
@@ -204,9 +204,9 @@ namespace vkhlf
   }
 
   template <typename T>
-  inline void CommandBuffer::pushConstants(std::shared_ptr<vkhlf::PipelineLayout> layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values)
+  inline void CommandBuffer::pushConstants(std::shared_ptr<vkhlf::PipelineLayout> const & layout, vk::ShaderStageFlags stageFlags, uint32_t start, vk::ArrayProxy<const T> values)
   {
-    m_commandBuffer.pushConstants<T>((vk::PipelineLayout)*layout, stageFlags, start, values);
+    m_commandBuffer.pushConstants<T>(*layout, stageFlags, start, values);
   }
 
   template <typename T>


### PR DESCRIPTION
Most of the APIs in VkHLF expect shared_ptrs of the types VkHLF creates, this matches that. This could also go some other ways, and I'm willing to make changes in that case. Perhaps we take a reference to a shared_ptr since we don't actually need the shared_ptr. We could also make this an overload so we maintain the previous API as well. Happy to make any changes.