### PR TITLE
Make various CMake related improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,6 @@ endif()
 
 set(VK_3RDPARTY_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdParty" CACHE STRING "CkSpp 3rdParty path")
 set(VK_BINARY_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${VK_CONFIG}")
-message( "VK_BINARY_PATH = ${VK_BINARY_PATH}" )
 
 # some useful macros
 MACRO(ADD_TARGET_PROPERTIES _target _name)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,15 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 #GLFW3 doesn't add the Vulkan include directories by default. Add them before.
 include_directories($ENV{VK_SDK_PATH}/include)
 
-option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" OFF)
-option(GLFW_BUILD_TESTS "Build the GLFW test programs" OFF)
-option(GLFW_BUILD_DOCS "Build the GLFW documentation" OFF)
-option(GLFW_INSTALL "Generate installation target" OFF)
-add_subdirectory(3rdparty/glfw)
+option( BUILD_VKCPP_GLFW "Build GLFW" ON)
+
+if( BUILD_VKCPP_GLFW )
+  option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" OFF)
+  option(GLFW_BUILD_TESTS "Build the GLFW test programs" OFF)
+  option(GLFW_BUILD_DOCS "Build the GLFW documentation" OFF)
+  option(GLFW_INSTALL "Generate installation target" OFF)
+  add_subdirectory(3rdparty/glfw)
+endif()
 
 #add glslang
 option(ENABLE_GLSLANG_BINARIES "Enable GLSLang Binaries" OFF)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
-cmake_policy(SET CMP0020 OLD)
 
 SET( BUILD_VKCPP_SAMPLES ON  CACHE BOOL "Build the VkCpp based samples" )
 
 if( BUILD_VKCPP_SAMPLES )
+  cmake_policy(SET CMP0020 OLD)
+
   FILE (GLOB linkunits ${CMAKE_CURRENT_SOURCE_DIR}/*)
 
   FOREACH( linkunit ${linkunits} )

--- a/vkhlf/CMakeLists.txt
+++ b/vkhlf/CMakeLists.txt
@@ -153,12 +153,17 @@ target_include_directories(VkHLF
   INTERFACE  "${PROJECT_SOURCE_DIR}"
 )
 
-target_link_libraries( VkHLF
+target_link_libraries(VkHLF
   ${OPENGL_gl_LIBRARY}
   ${VulkanLib}
   glslang
   OGLCompiler
   OSDependent
-  HLSL
   SPIRV
 )
+
+option(ENABLE_HLSL "Enables HLSL input support" OFF)
+
+if (ENABLE_HLSL)
+  target_link_libraries(VkHLF HLSL)
+endif()

--- a/vkhlf/CMakeLists.txt
+++ b/vkhlf/CMakeLists.txt
@@ -133,19 +133,29 @@ add_library( VkHLF SHARED
   ${PRIVATE}
 )
 
+If (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.7.2 OR
+    ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} EQUAL 3.7.2)
+  Find_Package(Vulkan)
+
+  Set(VulkanIncludeDir ${Vulkan_INCLUDE_DIRS})
+  Set(VulkanLib Vulkan::Vulkan)
+Else()
+  Set(VulkanIncludeDir "$ENV{VK_SDK_PATH}/include")
+  Set(VulkanLib "$ENV{VK_SDK_PATH}/Lib/vulkan-1.lib")
+EndIf()
+
 target_include_directories(VkHLF
   PUBLIC    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>
-  PUBLIC    "$ENV{VK_SDK_PATH}/include"
+  PUBLIC    "${VulkanIncludeDir}"
   PUBLIC    "${CMAKE_SOURCE_DIR}/3rdparty"
   INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>
-  INTERFACE "$ENV{VK_SDK_PATH}/include"
+  INTERFACE "${VulkanIncludeDir}"
   INTERFACE  "${PROJECT_SOURCE_DIR}"
 )
 
-
 target_link_libraries( VkHLF
   ${OPENGL_gl_LIBRARY}
-  "$ENV{VK_SDK_PATH}/Lib/vulkan-1.lib"
+  ${VulkanLib}
   glslang
   OGLCompiler
   OSDependent


### PR DESCRIPTION
- Removed an extraneous message statement
- Added option to not build GLFW
- Added option to not build require HLSL
- Added check to see if CMake version is high enough to use Find_Package for Vulkan. (Although maybe just require cmake >3.7.2 as it's almost 2 years old now.)